### PR TITLE
Add environment variable VUE_APP_API in Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      VUE_APP_API: ${{ secrets.VUE_APP_API }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Related to #32

Add environment variable `VUE_APP_API` in Github Actions.

* Add a new `env` section in `.github/workflows/deploy.yml` to define the `VUE_APP_API` environment variable with a value from GitHub secrets.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BolasLien/miniAttic-front-app/pull/33?shareId=648235f1-6176-40ae-9a34-032f3fe25faf).